### PR TITLE
Automatically flush all logged events

### DIFF
--- a/sentry/hook.go
+++ b/sentry/hook.go
@@ -58,10 +58,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 	hub := sentry.CurrentHub().Clone()
 	hub.CaptureEvent(&event)
 
-	//flush fatal events before exit
-	if entry.Level == logrus.FatalLevel{
-		Flush()
-	}
+	Flush()
 
 	return nil
 }


### PR DESCRIPTION
Assuming we only report events upwards of WarnLevel to Sentry this has no significant downsides, especially with async delivery. Explicit flush is mainly useful for sending a large number of debug/info events which Sentry wasn't designed for anyway. So it's better to prioritise removing unnecessary boilerplate from library consumers by making sure every fired event is flushed immediately.